### PR TITLE
feat: Dockerize the application for easy trial

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Git
+.git
+.gitignore
+
+# Python
+.venv
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.flake8
+
+# Project specific
+pdf/
+markdown/
+specs/
+.specify/
+.gemini/
+README.md
+LICENSE
+GEMINI.md
+pyproject.toml
+requirements.txt
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the source code to the working directory
+COPY src/ ./src
+
+# Specify the command to run on container start
+ENTRYPOINT ["python", "-m", "src.main"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,40 @@ This is a Python-based command-line tool to convert PDF files into high-quality,
 -   Automatically refine Markdown using the Gemini Pro model.
 -   Simple and easy-to-use CLI.
 
-## Installation
+## Quickstart (Docker)
+
+This is the easiest way to run the application without setting up a local Python environment.
+
+### Prerequisites
+
+-   Docker installed on your system.
+-   You have a Google Gemini API key.
+
+### Usage
+
+1.  **Set your Gemini API Key:**
+    ```bash
+    export GEMINI_API_KEY="YOUR_API_KEY"
+    ```
+
+2.  **Run the script:**
+    The `run-docker.sh` script will build the Docker image and run the converter on the PDF file you provide.
+
+    ```bash
+    ./run-docker.sh path/to/your/file.pdf
+    ```
+    For example:
+    ```bash
+    ./run-docker.sh pdf/sample.pdf
+    ```
+
+The converted Markdown file will be saved in the `markdown` directory.
+
+## Running from Source
+
+If you prefer to run the application from the source code, follow these steps.
+
+### 1. Installation
 
 1.  **Clone the repository:**
     ```bash
@@ -27,16 +60,15 @@ This is a Python-based command-line tool to convert PDF files into high-quality,
     pip install -r requirements.txt
     ```
 
-4.  **Set up your Gemini API Key:**
-    You need to have a Google Gemini API key to use the refinement feature.
+### 2. Configuration
 
-    -   Get your key from [Google AI Studio](https://aistudio.google.com/app/apikey).
-    -   Set it as an environment variable:
-        ```bash
-        export GEMINI_API_KEY="YOUR_API_KEY"
-        ```
+-   **Set up your Gemini API Key:**
+    Get your key from [Google AI Studio](https://aistudio.google.com/app/apikey) and set it as an environment variable:
+    ```bash
+    export GEMINI_API_KEY="YOUR_API_KEY"
+    ```
 
-## Usage
+### 3. Running the tool
 
 To convert a PDF, run the following command from the project's root directory:
 
@@ -46,18 +78,15 @@ python -m src.main /path/to/your/file.pdf
 
 The tool will create a new Markdown file in the `markdown/` directory.
 
-### Example
+## Configuration
 
-```bash
-python -m src.main pdf/sample.pdf
-```
+You can configure the application using the following environment variables:
 
-Output:
-```
-Converting sample.pdf...
-Refining Markdown with Gemini...
-Successfully created sample.md
-```
+-   `GEMINI_API_KEY`: **(Required)** Your Google Gemini API key.
+-   `GEMINI_MAX_WORKERS`: The maximum number of parallel workers for the Markdown refinement process. This can improve performance when processing large documents. The default value is `10`.
+    ```bash
+    export GEMINI_MAX_WORKERS=20
+    ```
 
 ## Development
 

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# This script builds the Docker image and runs the PDF to Markdown converter.
+#
+# Usage:
+#   ./run-docker.sh <path/to/your/file.pdf>
+#
+# Example:
+#   ./run-docker.sh pdf/sample.pdf
+#
+
+set -e
+
+IMAGE_NAME="pdf-to-markdown"
+PDF_FILE=$1
+
+if [ -z "$PDF_FILE" ]; then
+  echo "Usage: $0 <path/to/your/file.pdf>"
+  exit 1
+fi
+
+if [ ! -f "$PDF_FILE" ]; then
+  echo "Error: File not found at '$PDF_FILE'"
+  exit 1
+fi
+
+# Check if GEMINI_API_KEY is set
+if [ -z "$GEMINI_API_KEY" ]; then
+  echo "Error: GEMINI_API_KEY environment variable is not set."
+  echo "Please set it to your Google Gemini API key."
+  exit 1
+fi
+
+echo "Building Docker image..."
+docker build -t $IMAGE_NAME .
+
+echo "Running the converter on $PDF_FILE..."
+docker run --rm \
+  -v $(pwd)/pdf:/app/pdf \
+  -v $(pwd)/markdown:/app/markdown \
+  -e GEMINI_API_KEY="$GEMINI_API_KEY" \
+  $IMAGE_NAME \
+  "$PDF_FILE"
+
+echo "Conversion complete. Check the 'markdown' directory for the output."

--- a/specs/002-docker/data-model.md
+++ b/specs/002-docker/data-model.md
@@ -1,0 +1,3 @@
+# Data Model for Dockerization
+
+Not applicable. This feature is focused on creating a Docker image for the application and does not involve changes to the data model.

--- a/specs/002-docker/plan.md
+++ b/specs/002-docker/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Dockerize for Easy Trial
+
+**Branch**: `002-docker` | **Date**: 2025-09-20 | **Spec**: [link](./spec.md)
+**Input**: Feature specification from `/specs/002-docker/spec.md`
+
+## Execution Flow (/plan command scope)
+```
+1. Load feature spec from Input path
+   → If not found: ERROR "No feature spec at {path}"
+2. Fill Technical Context (scan for NEEDS CLARIFICATION)
+   → Detect Project Type from context (web=frontend+backend, mobile=app+api)
+   → Set Structure Decision based on project type
+3. Fill the Constitution Check section based on the content of the constitution document.
+4. Evaluate Constitution Check section below
+   → If violations exist: Document in Complexity Tracking
+   → If no justification possible: ERROR "Simplify approach first"
+   → Update Progress Tracking: Initial Constitution Check
+5. Execute Phase 0 → research.md
+   → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
+6. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, `GEMINI.md` for Gemini CLI, `QWEN.md` for Qwen Code or `AGENTS.md` for opencode).
+7. Re-evaluate Constitution Check section
+   → If new violations: Refactor design, return to Phase 1
+   → Update Progress Tracking: Post-Design Constitution Check
+8. Plan Phase 2 → Describe task generation approach (DO NOT create tasks.md)
+9. STOP - Ready for /tasks command
+```
+
+**IMPORTANT**: The /plan command STOPS at step 7. Phases 2-4 are executed by other commands:
+- Phase 2: /tasks command creates tasks.md
+- Phase 3-4: Implementation execution (manual or via tools)
+
+## Summary
+The project will be containerized using Docker to simplify the setup and trial process for new users. A `Dockerfile` will be created to build an image containing the Python application and its dependencies. The `README.md` will be updated with instructions on how to build and run the application using Docker.
+
+## Technical Context
+**Language/Version**: Python 3
+**Primary Dependencies**: `click`, `markitdown`, `google-generativeai`
+**Storage**: N/A
+**Testing**: `pytest`
+**Target Platform**: Docker
+**Project Type**: single
+**Performance Goals**: N/A
+**Constraints**: N/A
+**Scale/Scope**: Small CLI tool
+
+## Constitution Check
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The project constitution is a template and does not contain specific gates. Therefore, this check passes by default.
+
+## Project Structure
+
+### Documentation (this feature)
+```
+specs/002-docker/
+├── plan.md              # This file (/plan command output)
+├── research.md          # Phase 0 output (/plan command)
+├── data-model.md        # Phase 1 output (/plan command)
+├── quickstart.md        # Phase 1 output (/plan command)
+└── tasks.md             # Phase 2 output (/tasks command - NOT created by /plan)
+```
+
+### Source Code (repository root)
+```
+# Option 1: Single project (DEFAULT)
+src/
+├── converter.py
+├── main.py
+└── post_processor.py
+
+tests/
+├── test_converter.py
+└── test_post_processor.py
+```
+
+**Structure Decision**: Option 1: Single project
+
+## Phase 0: Outline & Research
+Completed. See `research.md`.
+
+## Phase 1: Design & Contracts
+Completed. See `data-model.md` and `quickstart.md`. No contracts are applicable for this feature.
+
+## Phase 2: Task Planning Approach
+*This section describes what the /tasks command will do - DO NOT execute during /plan*
+
+**Task Generation Strategy**:
+- Create a `Dockerfile` in the project root.
+- Create a `.dockerignore` file in the project root.
+- Update `README.md` with instructions from `quickstart.md`.
+- (Optional) Create a `run-docker.sh` script to simplify the `docker run` command.
+
+**Ordering Strategy**:
+1.  Create `.dockerignore`.
+2.  Create `Dockerfile`.
+3.  Update `README.md`.
+4.  (Optional) Create `run-docker.sh`.
+
+**Estimated Output**: 3-4 tasks in tasks.md
+
+**IMPORTANT**: This phase is executed by the /tasks command, NOT by /plan
+
+## Phase 3+: Future Implementation
+*These phases are beyond the scope of the /plan command*
+
+**Phase 3**: Task execution (/tasks command creates tasks.md)  
+**Phase 4**: Implementation (execute tasks.md following constitutional principles)  
+**Phase 5**: Validation (run tests, execute quickstart.md, performance validation)
+
+## Complexity Tracking
+*Fill ONLY if Constitution Check has violations that must be justified*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A       | N/A        | N/A                                 |
+
+
+## Progress Tracking
+*This checklist is updated during execution flow*
+
+**Phase Status**:
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [x] Phase 2: Task planning complete (/plan command - describe approach only)
+- [ ] Phase 3: Tasks generated (/tasks command)
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [x] All NEEDS CLARIFICATION resolved
+- [x] Complexity deviations documented
+
+---
+*Based on Constitution v2.1.1 - See `/memory/constitution.md`*

--- a/specs/002-docker/quickstart.md
+++ b/specs/002-docker/quickstart.md
@@ -1,0 +1,39 @@
+# Quickstart: Running with Docker
+
+This guide explains how to build and run the PDF to Markdown converter using Docker.
+
+## Prerequisites
+
+- Docker installed on your system.
+
+## Build the Docker Image
+
+1.  Clone the repository.
+2.  Navigate to the root directory of the project.
+3.  Build the Docker image by running the following command:
+
+    ```bash
+    docker build -t pdf-to-markdown .
+    ```
+
+## Run the Converter
+
+To run the converter, you need to mount a local directory (containing your PDF files) into the container.
+
+1.  Place the PDF you want to convert in a directory on your host machine (e.g., `./pdf`).
+2.  Create an output directory (e.g., `./markdown`).
+3.  Run the following command:
+
+    ```bash
+    docker run --rm \
+      -v $(pwd)/pdf:/app/pdf \
+      -v $(pwd)/markdown:/app/markdown \
+      pdf-to-markdown \
+      --input-path pdf/<your-pdf-file>.pdf \
+      --output-path markdown/<your-output-file>.md
+    ```
+
+    Replace `<your-pdf-file>.pdf` with the name of your PDF file and `<your-output-file>.md` with the desired output filename.
+
+The converted Markdown file will be available in the `./markdown` directory on your host machine.
+

--- a/specs/002-docker/research.md
+++ b/specs/002-docker/research.md
@@ -1,0 +1,30 @@
+# Research for Dockerization
+
+## Technology Choices
+
+### Containerization
+
+- **Decision**: Use Docker to containerize the application.
+- **Rationale**: Docker is the industry standard for containerization. It allows for easy packaging of the application and its dependencies, ensuring it runs consistently across different environments. This directly addresses the problem statement of simplifying the trial process for new users.
+- **Alternatives considered**: Podman, containerd. While viable, Docker has a larger community and more extensive documentation, making it more suitable for this project's goal of easy adoption.
+
+### Container Registry
+
+- **Decision**: Use Docker Hub for distributing the image.
+- **Rationale**: Docker Hub is the default and most widely used container registry. It's a public registry that's easy to use and well-integrated with the Docker CLI. For a public, open-source project, it's the simplest choice for distribution. The user's initial thought was "dockerhub면 되겠지 대안 있나?" ("Docker Hub should be fine, are there alternatives?"). While there are alternatives, Docker Hub is the most straightforward for this use case.
+- **Alternatives considered**:
+    - **GitHub Container Registry (GHCR)**: A strong alternative, especially since the code is likely on GitHub. It integrates well with GitHub Actions.
+    - **GitLab Container Registry**: Similar to GHCR, but for GitLab users.
+    - **Cloud-specific registries (ECR, ACR, GCR)**: These are more suitable for applications deployed within a specific cloud ecosystem.
+    - For the purpose of a simple, public distribution, Docker Hub remains the most logical choice.
+
+## Implementation Details
+
+### Dockerfile
+
+- A multi-stage build is not necessary for this project's scope (as per the spec).
+- A simple `Dockerfile` will be created, using a Python base image, copying the source code, installing dependencies, and setting an entrypoint.
+
+### `.dockerignore`
+
+- A `.dockerignore` file will be created to prevent unnecessary files (like `.git`, `.venv`, `__pycache__`) from being included in the Docker image, which helps to keep the image size small.

--- a/specs/002-docker/spec.md
+++ b/specs/002-docker/spec.md
@@ -1,0 +1,35 @@
+# Feature Spec: Dockerize for Easy Trial
+
+- **Feature**: `002-docker`
+- **Epic**: `experience`
+
+## 1. Problem
+
+Currently, trying out this project requires setting up a Python environment and installing dependencies. This can be a barrier for users who just want to quickly test the functionality.
+
+## 2. Solution
+
+We will create a Docker image for the application. This will allow users to run the CLI tool in a containerized environment without needing to install Python or any dependencies on their host machine.
+
+### Dockerfile
+
+- Use a suitable Python base image.
+- Copy the source code into the image.
+- Install the dependencies from `requirements.txt`.
+- Set up an entrypoint to run the CLI tool.
+
+### User Experience
+
+A user can build the Docker image and then run the tool by passing the PDF file and other arguments to the `docker run` command. We should also provide a simple script or instructions to make this process as easy as possible.
+
+## 3. Plan
+
+1.  Create a `Dockerfile` in the project root.
+2.  Add `.dockerignore` to exclude unnecessary files from the image.
+3.  Update `README.md` with instructions on how to build and run the application using Docker.
+4.  (Optional) Create a shell script (e.g., `run-docker.sh`) to simplify the `docker run` command.
+
+## 4. Out of Scope
+
+-   Publishing the Docker image to a public registry.
+-   Multi-stage Docker builds for production optimization. This is focused on a development/trial setup.

--- a/specs/002-docker/tasks.md
+++ b/specs/002-docker/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Dockerize for Easy Trial
+
+**Input**: Design documents from `/specs/002-docker/`
+**Prerequisites**: plan.md (required), research.md, data-model.md, quickstart.md
+
+## Phase 3.1: Setup
+- [ ] T001 [P] Create `.dockerignore` at the repository root to exclude unnecessary files from the Docker image.
+- [ ] T002 Create `Dockerfile` at the repository root to define the Docker image for the application.
+
+## Phase 3.2: Core Implementation
+- [ ] T003 Update `README.md` with instructions on how to build and run the application using Docker, based on `specs/002-docker/quickstart.md`.
+
+## Phase 3.3: Polish
+- [ ] T004 (Optional) Create a `run-docker.sh` script at the repository root to simplify the `docker run` command for users.
+
+## Dependencies
+- T001 and T002 have no dependencies.
+- T003 should be done after T002, as the `README.md` will refer to the `Dockerfile`.
+- T004 is optional and can be done at any time after T002.
+
+## Parallel Example
+Tasks T001 and T002 can be run in parallel as they involve creating two different files.
+
+```
+# Launch T001 and T002 together:
+Task: "Create .dockerignore at the repository root to exclude unnecessary files from the Docker image."
+Task: "Create Dockerfile at the repository root to define the Docker image for the application."
+```


### PR DESCRIPTION
This commit introduces Docker support to the project, allowing users to run the application without setting up a local Python environment.

- Adds a `Dockerfile` to build the application image.
- Includes a `.dockerignore` file to keep the image size small.
- Provides a `run-docker.sh` script for convenient execution.
- Updates `README.md` with a new "Quickstart (Docker)" section and restructures the document for clarity.
- Adds planning and design artifacts under `specs/002-docker/`.